### PR TITLE
Include link to PR page + more context for WARNING/BUG in emails

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -80,6 +80,8 @@ PW Link:{pw_link}
 
 {content}
 
+{test_log_link}
+
 ---
 Regards,
 Linux Bluetooth
@@ -122,9 +124,11 @@ def get_receivers(email_config, submitter):
 def send_email(ci_data, content):
     headers = {}
     email_config = ci_data.config['email']
+    pr = ci_data.gh.get_pr(ci_data.config['pr_num'], force=True)
 
     body = EMAIL_MESSAGE.format(pw_link=ci_data.series['web_url'],
-                                content=content)
+                                content=content,
+                                test_log_link=f"{pr.html_url}/checks")
 
     headers['In-Reply-To'] = ci_data.patch_1['msgid']
     headers['References'] = ci_data.patch_1['msgid']

--- a/ci/testrunner.py
+++ b/ci/testrunner.py
@@ -75,7 +75,8 @@ class TestRunner(Base):
         failed_tc = []
 
         # verdict result
-        for line in stdout_clean.splitlines():
+        lines = stdout_clean.splitlines()
+        for lineno, line in enumerate(lines):
             if re.search(r"^Total: ", line):
                 self.test_summary = line
 
@@ -113,7 +114,14 @@ class TestRunner(Base):
 
             if re.search(r"^(BUG:|WARNING:|general protection fault|Kernel panic)", line):
                 bug = line
-                self.add_failure(line)
+                splat = lines[lineno:lineno+40]
+                for j, splatline in enumerate(splat):
+                    if '</TASK>' in splatline or '---[ end trace' in splatline:
+                        splat = splat[:j]
+                        break
+                else:
+                    splat = splat + ["..."]
+                self.add_failure("\n".join(splat))
 
             if re.search(r"^Test Summary", line):
                 self.log_dbg("Start to check fail in the line")


### PR DESCRIPTION
Add link to test PR page in sent email, so that the full test log can be
found if needed.

Getting kernel BUG:, WARNING: etc is generally no-go, so include more
context already in the email/post test summary.

---------

Sending emails part is hard to test locally, but probably is OK.

IIUC, these changes would have to go to https://github.com/tedd-an/bzcafe to apply to the kernel test bot.

Example output (in case of lots of warnings):

<details>

```
Test Summary:
TestRunner_iso-tester         FAIL      68.56 seconds

Details
##############################
Test: TestRunner_iso-tester - FAIL
Desc: Run iso-tester with test-runner
Output:
WARNING: suspicious RCU usage
6.16.0-rc6-01737-gb9b65e1e560f #655 Not tainted
-----------------------------
./include/net/bluetooth/hci_core.h:1540 wrong hci_conn* locking!

other info that might help us debug this:


rcu_scheduler_active = 2, debug_locks = 1
3 locks held by kworker/u5:0/44:
 #0: ffff888002755140 ((wq_completion)hci0#2){+.+.}-{0:0}, at: process_one_work+0xc3b/0x13c0
 #1: ffff8880019afd98 ((work_completion)(&hdev->cmd_sync_work)){+.+.}-{0:0}, at: process_one_work+0x78b/0x13c0
 #2: ffff8880020f8da8 (&hdev->req_lock){+.+.}-{4:4}, at: hci_cmd_sync_work+0x117/0x380

stack backtrace:
CPU: 0 UID: 0 PID: 44 Comm: kworker/u5:0 Not tainted 6.16.0-rc6-01737-gb9b65e1e560f #655 PREEMPT(none) 
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.17.0-5.fc42 04/01/2014
Workqueue: hci0 hci_cmd_sync_work
Call Trace:
 <TASK>
 dump_stack_lvl+0x3a/0x60
 lockdep_rcu_suspicious.cold+0x55/0x93
 hci_lookup_le_connect+0x22e/0x310
 hci_update_passive_scan_sync+0x39f/0x730
 hci_cmd_sync_work+0x156/0x380
 process_one_work+0x7ed/0x13c0
 ? __pfx_process_one_work+0x10/0x10
 ? lock_acquire+0xf2/0x2a0
 ? lock_is_held_type+0x84/0xf0
 ? assign_work+0x151/0x390
 worker_thread+0x601/0xff0
 ? __pfx_worker_thread+0x10/0x10
 kthread+0x3a5/0x760
 ? lockdep_hardirqs_on_prepare+0xd0/0x180
 ? __pfx_kthread+0x10/0x10
 ret_from_fork+0x362/0x4d0
 ? __pfx_kthread+0x10/0x10
 ret_from_fork_asm+0x19/0x30
WARNING: suspicious RCU usage
6.16.0-rc6-01737-gb9b65e1e560f #655 Not tainted
-----------------------------
./include/net/bluetooth/hci_core.h:1342 wrong hci_conn* locking!

other info that might help us debug this:


rcu_scheduler_active = 2, debug_locks = 1
3 locks held by kworker/u5:0/44:
 #0: ffff888002755140 ((wq_completion)hci0#2){+.+.}-{0:0}, at: process_one_work+0xc3b/0x13c0
 #1: ffff8880019afd98 ((work_completion)(&hdev->cmd_sync_work)){+.+.}-{0:0}, at: process_one_work+0x78b/0x13c0
 #2: ffff8880020f8da8 (&hdev->req_lock){+.+.}-{4:4}, at: hci_cmd_sync_work+0x117/0x380

stack backtrace:
CPU: 0 UID: 0 PID: 44 Comm: kworker/u5:0 Not tainted 6.16.0-rc6-01737-gb9b65e1e560f #655 PREEMPT(none) 
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.17.0-5.fc42 04/01/2014
Workqueue: hci0 hci_cmd_sync_work
Call Trace:
 <TASK>
 dump_stack_lvl+0x3a/0x60
 lockdep_rcu_suspicious.cold+0x55/0x93
 set_cig_params_sync+0x304/0xe70
 ? lock_acquire+0xf2/0x2a0
 ? hci_cmd_sync_work+0x117/0x380
 ? __pfx_set_cig_params_sync+0x10/0x10
 ? __pfx___might_resched+0x10/0x10
 ? kasan_quarantine_put+0xcf/0x220
 ? kfree+0xf8/0x320
 hci_cmd_sync_work+0x156/0x380
 process_one_work+0x7ed/0x13c0
 ? __pfx_process_one_work+0x10/0x10
 ? lock_acquire+0xf2/0x2a0
 ? lock_is_held_type+0x84/0xf0
 ? assign_work+0x151/0x390
 worker_thread+0x601/0xff0
 ? __pfx_worker_thread+0x10/0x10
 kthread+0x3a5/0x760
 ? lockdep_hardirqs_on_prepare+0xd0/0x180
 ? __pfx_kthread+0x10/0x10
...
WARNING: suspicious RCU usage
6.16.0-rc6-01737-gb9b65e1e560f #655 Not tainted
-----------------------------
./include/net/bluetooth/hci_core.h:1308 wrong hci_conn* locking!

other info that might help us debug this:


rcu_scheduler_active = 2, debug_locks = 1
3 locks held by kworker/u5:0/44:
 #0: ffff888002755140 ((wq_completion)hci0#2){+.+.}-{0:0}, at: process_one_work+0xc3b/0x13c0
 #1: ffff8880019afd98 ((work_completion)(&hdev->cmd_sync_work)){+.+.}-{0:0}, at: process_one_work+0x78b/0x13c0
 #2: ffff8880020f8da8 (&hdev->req_lock){+.+.}-{4:4}, at: hci_cmd_sync_work+0x117/0x380

stack backtrace:
CPU: 0 UID: 0 PID: 44 Comm: kworker/u5:0 Not tainted 6.16.0-rc6-01737-gb9b65e1e560f #655 PREEMPT(none) 
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.17.0-5.fc42 04/01/2014
Workqueue: hci0 hci_cmd_sync_work
Call Trace:
 <TASK>
 dump_stack_lvl+0x3a/0x60
 lockdep_rcu_suspicious.cold+0x55/0x93
 set_cig_params_sync+0xac4/0xe70
 ? __pfx_set_cig_params_sync+0x10/0x10
 ? __pfx___might_resched+0x10/0x10
 ? kasan_quarantine_put+0xcf/0x220
 ? kfree+0xf8/0x320
 hci_cmd_sync_work+0x156/0x380
 process_one_work+0x7ed/0x13c0
 ? __pfx_process_one_work+0x10/0x10
 ? lock_acquire+0xf2/0x2a0
 ? lock_is_held_type+0x84/0xf0
 ? assign_work+0x151/0x390
 worker_thread+0x601/0xff0
 ? __pfx_worker_thread+0x10/0x10
 kthread+0x3a5/0x760
 ? lockdep_hardirqs_on_prepare+0xd0/0x180
 ? __pfx_kthread+0x10/0x10
 ret_from_fork+0x362/0x4d0
 ? __pfx_kthread+0x10/0x10
...
WARNING: suspicious RCU usage
6.16.0-rc6-01737-gb9b65e1e560f #655 Not tainted
-----------------------------
./include/net/bluetooth/hci_core.h:1117 wrong hci_conn* locking!

other info that might help us debug this:


rcu_scheduler_active = 2, debug_locks = 1
3 locks held by kworker/u5:0/44:
 #0: ffff888002755140 ((wq_completion)hci0#2){+.+.}-{0:0}, at: process_one_work+0xc3b/0x13c0
 #1: ffff8880019afd98 ((work_completion)(&hdev->cmd_sync_work)){+.+.}-{0:0}, at: process_one_work+0x78b/0x13c0
 #2: ffff8880020f8da8 (&hdev->req_lock){+.+.}-{4:4}, at: hci_cmd_sync_work+0x117/0x380

stack backtrace:
CPU: 0 UID: 0 PID: 44 Comm: kworker/u5:0 Not tainted 6.16.0-rc6-01737-gb9b65e1e560f #655 PREEMPT(none) 
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.17.0-5.fc42 04/01/2014
Workqueue: hci0 hci_cmd_sync_work
Call Trace:
 <TASK>
 dump_stack_lvl+0x3a/0x60
 lockdep_rcu_suspicious.cold+0x55/0x93
 hci_conn_valid+0x1c1/0x280
 hci_le_create_conn_sync+0x105/0x24b0
 ? lock_acquire+0xf2/0x2a0
 ? __pfx_hci_le_create_conn_sync+0x10/0x10
 ? __pfx___might_resched+0x10/0x10
 ? lockdep_hardirqs_on_prepare+0xd0/0x180
 ? __mutex_lock+0x2aa/0x1830
 ? __lock_acquire+0x47e/0x2610
 ? hci_cmd_sync_work+0x117/0x380
 ? hci_cmd_sync_work+0xd6/0x380
 ? __pfx___mutex_lock+0x10/0x10
 ? __pfx___mutex_unlock_slowpath+0x10/0x10
 hci_cmd_sync_work+0x156/0x380
 process_one_work+0x7ed/0x13c0
 ? process_one_work+0x817/0x13c0
 ? __pfx_process_one_work+0x10/0x10
 ? lock_acquire+0xf2/0x2a0
 ? lock_is_held_type+0x84/0xf0
...
WARNING: suspicious RCU usage
6.16.0-rc6-01737-gb9b65e1e560f #655 Not tainted
-----------------------------
./include/net/bluetooth/hci_core.h:1117 wrong hci_conn* locking!

other info that might help us debug this:


rcu_scheduler_active = 2, debug_locks = 1
3 locks held by kworker/u5:2/46:
 #0: ffff888002755140 ((wq_completion)hci0#2){+.+.}-{0:0}, at: process_one_work+0xc3b/0x13c0
 #1: ffff888001cafd98 ((work_completion)(&hdev->cmd_sync_work)){+.+.}-{0:0}, at: process_one_work+0x78b/0x13c0
 #2: ffff8880020f8da8 (&hdev->req_lock){+.+.}-{4:4}, at: hci_cmd_sync_work+0x117/0x380

stack backtrace:
CPU: 0 UID: 0 PID: 46 Comm: kworker/u5:2 Not tainted 6.16.0-rc6-01737-gb9b65e1e560f #655 PREEMPT(none) 
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.17.0-5.fc42 04/01/2014
Workqueue: hci0 hci_cmd_sync_work
Call Trace:
 <TASK>
 dump_stack_lvl+0x3a/0x60
 lockdep_rcu_suspicious.cold+0x55/0x93
 abort_conn_sync+0x201/0x2e0
 hci_cmd_sync_work+0x156/0x380
 process_one_work+0x7ed/0x13c0
 ? process_one_work+0x817/0x13c0
 ? __pfx_process_one_work+0x10/0x10
 ? lock_acquire+0xf2/0x2a0
 ? lock_is_held_type+0x84/0xf0
 ? assign_work+0x151/0x390
 worker_thread+0x601/0xff0
 ? __pfx_worker_thread+0x10/0x10
 ? __kthread_parkme+0x8a/0x2b0
 ? __pfx_worker_thread+0x10/0x10
 ? __pfx_worker_thread+0x10/0x10
 kthread+0x3a5/0x760
 ? lockdep_hardirqs_on_prepare+0xd0/0x180
 ? __pfx_kthread+0x10/0x10
 ret_from_fork+0x362/0x4d0
 ? __pfx_kthread+0x10/0x10
...
WARNING: suspicious RCU usage
6.16.0-rc6-01737-gb9b65e1e560f #655 Not tainted
-----------------------------
./include/net/bluetooth/hci_core.h:1236 wrong hci_conn* locking!

other info that might help us debug this:


rcu_scheduler_active = 2, debug_locks = 1
2 locks held by kworker/u5:2/188:
 #0: ffff888002755940 ((wq_completion)hci0#2){+.+.}-{0:0}, at: process_one_work+0xc3b/0x13c0
 #1: ffff888001d1fd98 ((work_completion)(&hdev->rx_work)){+.+.}-{0:0}, at: process_one_work+0x78b/0x13c0

stack backtrace:
CPU: 0 UID: 0 PID: 188 Comm: kworker/u5:2 Not tainted 6.16.0-rc6-01737-gb9b65e1e560f #655 PREEMPT(none) 
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.17.0-5.fc42 04/01/2014
Workqueue: hci0 hci_rx_work
Call Trace:
 <TASK>
 dump_stack_lvl+0x3a/0x60
 lockdep_rcu_suspicious.cold+0x55/0x93
 hci_num_comp_pkts_evt+0x484/0xaf0
 hci_event_packet+0x7ba/0xee0
 ? __pfx_hci_num_comp_pkts_evt+0x10/0x10
 ? __pfx_hci_event_packet+0x10/0x10
 ? mark_held_locks+0x40/0x70
 ? trace_hardirqs_on+0x17/0xd0
 hci_rx_work+0x672/0x1510
 ? lock_release+0xcf/0x290
 process_one_work+0x7ed/0x13c0
 ? __pfx_process_one_work+0x10/0x10
 ? lock_acquire+0xf2/0x2a0
 ? lock_is_held_type+0x84/0xf0
 ? assign_work+0x151/0x390
 worker_thread+0x601/0xff0
 ? __pfx_worker_thread+0x10/0x10
 ? __kthread_parkme+0x8a/0x2b0
 ? __pfx_worker_thread+0x10/0x10
 ? __pfx_worker_thread+0x10/0x10
 kthread+0x3a5/0x760
...
WARNING: suspicious RCU usage
6.16.0-rc6-01737-gb9b65e1e560f #655 Not tainted
-----------------------------
./include/net/bluetooth/hci_core.h:1280 wrong hci_conn* locking!

other info that might help us debug this:


rcu_scheduler_active = 2, debug_locks = 1
3 locks held by kworker/u5:0/225:
 #0: ffff888001328140 ((wq_completion)hci0){+.+.}-{0:0}, at: process_one_work+0xc3b/0x13c0
 #1: ffff888001d1fd98 ((work_completion)(&hdev->cmd_sync_work)){+.+.}-{0:0}, at: process_one_work+0x78b/0x13c0
 #2: ffff8880023e4da8 (&hdev->req_lock){+.+.}-{4:4}, at: hci_cmd_sync_work+0x117/0x380

stack backtrace:
CPU: 0 UID: 0 PID: 225 Comm: kworker/u5:0 Not tainted 6.16.0-rc6-01737-gb9b65e1e560f #655 PREEMPT(none) 
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.17.0-5.fc42 04/01/2014
Workqueue: hci0 hci_cmd_sync_work
Call Trace:
 <TASK>
 dump_stack_lvl+0x3a/0x60
 lockdep_rcu_suspicious.cold+0x55/0x93
 hci_passive_scan_sync+0x663/0x1b30
 ? __pfx_hci_passive_scan_sync+0x10/0x10
 ? hci_lookup_le_connect+0x31/0x310
 ? find_held_lock+0x2b/0x80
 ? hci_lookup_le_connect+0x16c/0x310
 ? lock_release+0xcf/0x290
 hci_update_passive_scan_sync+0x3bd/0x730
 hci_cmd_sync_work+0x156/0x380
 process_one_work+0x7ed/0x13c0
 ? __pfx_process_one_work+0x10/0x10
 ? lock_acquire+0xf2/0x2a0
 ? lock_is_held_type+0x84/0xf0
 ? assign_work+0x151/0x390
 worker_thread+0x601/0xff0
 ? __pfx_worker_thread+0x10/0x10
 kthread+0x3a5/0x760
 ? lockdep_hardirqs_on_prepare+0xd0/0x180
 ? __pfx_kthread+0x10/0x10
...
WARNING: suspicious RCU usage
6.16.0-rc6-01737-gb9b65e1e560f #655 Not tainted
-----------------------------
./include/net/bluetooth/hci_core.h:1182 wrong hci_conn* locking!

other info that might help us debug this:


rcu_scheduler_active = 2, debug_locks = 1
3 locks held by kworker/u5:0/343:
 #0: ffff888002365940 ((wq_completion)hci0){+.+.}-{0:0}, at: process_one_work+0xc3b/0x13c0
 #1: ffff8880019ffd98 ((work_completion)(&hdev->cmd_sync_work)){+.+.}-{0:0}, at: process_one_work+0x78b/0x13c0
 #2: ffff888001ed0da8 (&hdev->req_lock){+.+.}-{4:4}, at: hci_cmd_sync_work+0x117/0x380

stack backtrace:
CPU: 0 UID: 0 PID: 343 Comm: kworker/u5:0 Not tainted 6.16.0-rc6-01737-gb9b65e1e560f #655 PREEMPT(none) 
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.17.0-5.fc42 04/01/2014
Workqueue: hci0 hci_cmd_sync_work
Call Trace:
 <TASK>
 dump_stack_lvl+0x3a/0x60
 lockdep_rcu_suspicious.cold+0x55/0x93
 hci_passive_scan_sync+0x1506/0x1b30
 ? __pfx_hci_passive_scan_sync+0x10/0x10
 ? hci_lookup_le_connect+0x31/0x310
 ? find_held_lock+0x2b/0x80
 ? hci_lookup_le_connect+0x16c/0x310
 ? lock_release+0xcf/0x290
 hci_update_passive_scan_sync+0x3bd/0x730
 hci_le_pa_create_sync+0x12b/0x5c0
 ? __pfx_hci_le_pa_create_sync+0x10/0x10
 hci_cmd_sync_work+0x156/0x380
 process_one_work+0x7ed/0x13c0
 ? __pfx_process_one_work+0x10/0x10
 ? lock_acquire+0xf2/0x2a0
 ? lock_is_held_type+0x84/0xf0
 ? assign_work+0x151/0x390
 worker_thread+0x601/0xff0
 ? __pfx_worker_thread+0x10/0x10
 kthread+0x3a5/0x760
...
Total: 135, Passed: 135 (100.0%), Failed: 0, Not Run: 0
```

</details>