### PR TITLE
ci: add CheckKernelLLVM

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -396,6 +396,9 @@ def create_test_list_kernel(ci_data):
     # BuildKernel32
     test_list.append(ci.BuildKernel32(ci_data, kernel_config=kernel_config))
 
+    # CheckKernelLLVM
+    test_list.append(ci.CheckKernelLLVM(ci_data, kernel_config=kernel_config))
+
     # TestRunnerSetup
     tester_config = os.path.join(ci_data.config['bluez_dir'],
                                  "doc", "tester.config")

--- a/ci.py
+++ b/ci.py
@@ -66,6 +66,8 @@ def parse_args():
                     help='Ratch root directory.')
     ap.add_argument('-d', '--dry-run', action='store_true', default=False,
                     help='Run it without uploading the result. default=False')
+    ap.add_argument('-j', '--jobs', action='store', type=str, default="4",
+                    help='Number of make jobs (number or "auto"). default=4')
 
     # Positional parameter
     ap.add_argument('space', choices=['user', 'kernel'],
@@ -504,6 +506,9 @@ def main():
         log_error(f"Invalid parameter(space) {args.space}")
         sys.exit(1)
 
+    if args.jobs == "auto":
+        args.jobs = str(os.cpu_count())
+
     ci_data = Context(config_file=os.path.abspath(args.config),
                       github_repo=args.repo,
                       src_dir=main_src,
@@ -511,7 +516,7 @@ def main():
                       branch=args.branch, dry_run=args.dry_run,
                       bluez_dir=args.bluez_dir, ell_dir=args.ell_dir,
                       kernel_dir=args.kernel_dir, pr_num=args.pr_num,
-                      space=args.space)
+                      space=args.space, jobs=args.jobs)
 
     # Setup Source for the test that needs to access the base like incremental
     # build.

--- a/ci.py
+++ b/ci.py
@@ -49,6 +49,15 @@ def check_args(args):
 
     return True
 
+def check_args_jobs(value):
+    if value == "auto":
+        return os.cpu_count()
+    else:
+        v = int(value)
+        if v <= 0:
+            raise ValueError("Invalid job count")
+        return v
+
 def parse_args():
     ap = argparse.ArgumentParser(description="Run CI tests")
     ap.add_argument('-c', '--config', default='./config.json',
@@ -66,6 +75,8 @@ def parse_args():
                     help='Ratch root directory.')
     ap.add_argument('-d', '--dry-run', action='store_true', default=False,
                     help='Run it without uploading the result. default=False')
+    ap.add_argument('-j', '--jobs', action='store', type=check_args_jobs, default="4",
+                    help='Number of make jobs (number or "auto"). default=4')
 
     # Positional parameter
     ap.add_argument('space', choices=['user', 'kernel'],
@@ -614,7 +625,7 @@ def main():
                       branch=args.branch, dry_run=args.dry_run,
                       bluez_dir=args.bluez_dir, ell_dir=args.ell_dir,
                       kernel_dir=args.kernel_dir, pr_num=args.pr_num,
-                      space=args.space)
+                      space=args.space, jobs=args.jobs)
 
     # Setup Source for the test that needs to access the base like incremental
     # build and scan build. Fetch origin/master so we have the base branch

--- a/ci.py
+++ b/ci.py
@@ -499,6 +499,9 @@ def create_test_list_kernel(ci_data):
     # BuildKernel32
     test_list.append(ci.BuildKernel32(ci_data, kernel_config=kernel_config))
 
+    # CheckKernelLLVM
+    test_list.append(ci.CheckKernelLLVM(ci_data, kernel_config=kernel_config))
+
     # TestRunnerSetup
     tester_config = os.path.join(ci_data.config['bluez_dir'],
                                  "doc", "tester.config")

--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -19,4 +19,5 @@ from .testrunnersetup import TestRunnerSetup
 from .checksparse import CheckSparse
 from .checkallwarning import CheckAllWarning
 from .checksmatch import CheckSmatch
+from .checkkernelllvm import CheckKernelLLVM
 

--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -21,4 +21,4 @@ from .checkallwarning import CheckAllWarning
 from .checksmatch import CheckSmatch
 from .verifyfixes import VerifyFixes
 from .verifysignedoff import VerifySignedoff
-
+from .checkkernelllvm import CheckKernelLLVM

--- a/ci/buildbluez.py
+++ b/ci/buildbluez.py
@@ -29,7 +29,8 @@ class BuildBluez(GenericBuild):
             self.dry_run = dry_run
 
         super().__init__(config_params=config_params, work_dir=self.src_dir,
-                         make_params=self.make_params)
+                         make_params=self.make_params,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/buildell.py
+++ b/ci/buildell.py
@@ -18,7 +18,8 @@ class BuildEll(GenericBuild):
         self.desc = "Build and Install ELL"
         self.ci_data = ci_data
 
-        super().__init__(work_dir=ci_data.config['ell_dir'], install=True)
+        super().__init__(work_dir=ci_data.config['ell_dir'], install=True,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/buildkernel.py
+++ b/ci/buildkernel.py
@@ -46,7 +46,8 @@ class BuildKernel(GenericKernelBuild):
         self.stderr = None
 
         super().__init__(kernel_config=kernel_config, simple_build=simple_build,
-                         make_params=make_params, work_dir=self.src_dir)
+                         make_params=make_params, work_dir=self.src_dir,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/buildkernel32.py
+++ b/ci/buildkernel32.py
@@ -49,7 +49,8 @@ class BuildKernel32(GenericKernelBuild):
         self.log_dbg(f"New config for 32bit is created: {new_config}")
 
         super().__init__(kernel_config=new_config, simple_build=simple_build,
-                         make_params=make_params, work_dir=self.src_dir)
+                         make_params=make_params, work_dir=self.src_dir,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/checkallwarning.py
+++ b/ci/checkallwarning.py
@@ -37,7 +37,8 @@ class CheckAllWarning(GenericKernelBuild):
             make_params = ['W=1']
 
         super().__init__(kernel_config=kernel_config, simple_build=True,
-                         make_params=make_params, work_dir=self.src_dir)
+                         make_params=make_params, work_dir=self.src_dir,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/checkallwarning.py
+++ b/ci/checkallwarning.py
@@ -10,7 +10,8 @@ class CheckAllWarning(GenericKernelBuild):
     This class runs the kernel build with all warning enabled.
     """
 
-    def __init__(self, ci_data, kernel_config=None, src_dir=None, dry_run=None):
+    def __init__(self, ci_data, kernel_config=None, src_dir=None, dry_run=None,
+                 make_params=None):
 
         self.name = "CheckAllWarning"
         self.desc = "Run linux kernel with all warning enabled"
@@ -30,8 +31,13 @@ class CheckAllWarning(GenericKernelBuild):
             self.log_dbg(f"Override the dry_run flag: {dry_run}")
             self.dry_run = dry_run
 
+        if make_params:
+            make_params = ['W=1'] + make_params
+        else:
+            make_params = ['W=1']
+
         super().__init__(kernel_config=kernel_config, simple_build=True,
-                         make_params=['W=1'], work_dir=self.src_dir)
+                         make_params=make_params, work_dir=self.src_dir)
 
         self.log_dbg("Initialization completed")
 
@@ -52,7 +58,7 @@ class CheckAllWarning(GenericKernelBuild):
         if self.verdict == Verdict.FAIL:
             submit_pw_check(self.ci_data.pw, self.ci_data.patch_1,
                             self.name, Verdict.FAIL,
-                            "CheckAllWarning: FAIL: " + self.output,
+                            f"{self.name}: FAIL: " + self.output,
                             None, self.dry_run)
             # Test verdict and output is already set by the super().run().
             # Just raising EndTest exception is enough here
@@ -64,7 +70,7 @@ class CheckAllWarning(GenericKernelBuild):
             # Build success
             submit_pw_check(self.ci_data.pw, self.ci_data.patch_1,
                             self.name, Verdict.PASS,
-                            "CheckAllWarning PASS",
+                            f"{self.name} PASS",
                             None, self.dry_run)
             # Actually no need to call success() here. But add it here just for
             # reference
@@ -86,7 +92,7 @@ class CheckAllWarning(GenericKernelBuild):
             # Found error and return warning
             submit_pw_check(self.ci_data.pw, self.ci_data.patch_1,
                             self.name, Verdict.WARNING,
-                            "CheckSparse WARNING " + output_str,
+                            f"{self.name} WARNING " + output_str,
                             None, self.dry_run)
             self.warning(output_str)
             return
@@ -94,7 +100,7 @@ class CheckAllWarning(GenericKernelBuild):
         # Build success
         submit_pw_check(self.ci_data.pw, self.ci_data.patch_1,
                         self.name, Verdict.PASS,
-                        "CheckSparse PASS",
+                        f"{self.name} PASS",
                         None, self.dry_run)
         # Actually no need to call success() here. But add it here just for
         # reference

--- a/ci/checkkernelllvm.py
+++ b/ci/checkkernelllvm.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import re
+
+from ci import Verdict, EndTest, submit_pw_check
+from ci import CheckAllWarning
+
+class CheckKernelLLVM(CheckAllWarning):
+    """Build kernel with LLVM + context analysis
+    """
+
+    def __init__(self, ci_data, kernel_config=None, src_dir=None, dry_run=None):
+        # Enable context analysis unconditionally
+        kernel_config = self.make_kernel_config(kernel_config)
+
+        super().__init__(ci_data, kernel_config=kernel_config, src_dir=src_dir,
+                         dry_run=dry_run, make_params=["LLVM=1"])
+
+        self.name = "CheckKernelLLVM"
+        self.desc = "Build kernel with LLVM + context analysis"
+
+    def make_kernel_config(self, old_kernel_config):
+        kernel_config = "/build_kernel_llvm.config"
+        if not old_kernel_config:
+            old_kernel_config = '/bluetooth_build.config'
+
+        with open(old_kernel_config, "r") as f:
+            config_text = f.read()
+        config_text += "\n\nCONFIG_WARN_CONTEXT_ANALYSIS=y"
+        with open(kernel_config, "w") as f:
+            f.write(config_text)
+
+        return kernel_config

--- a/ci/checkkernelllvm.py
+++ b/ci/checkkernelllvm.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import re
+import shutil
+
+from ci import Verdict, EndTest, submit_pw_check
+from ci import CheckAllWarning
+
+class CheckKernelLLVM(CheckAllWarning):
+    """Build kernel with LLVM + context analysis
+    """
+
+    def __init__(self, ci_data, kernel_config=None, src_dir=None, dry_run=None):
+        # Enable context analysis unconditionally
+        kernel_config = self.make_kernel_config(kernel_config)
+
+        super().__init__(ci_data, kernel_config=kernel_config, src_dir=src_dir,
+                         dry_run=dry_run, make_params=["LLVM=1"])
+
+        self.name = "CheckKernelLLVM"
+        self.desc = "Build kernel with LLVM + context analysis"
+
+    def run(self):
+        if not shutil.which("clang"):
+            self.skip("Clang not found")
+        super().run()
+
+    def make_kernel_config(self, old_kernel_config):
+        kernel_config = "/build_kernel_llvm.config"
+        if not old_kernel_config:
+            old_kernel_config = '/bluetooth_build.config'
+
+        with open(old_kernel_config, "r") as f:
+            config_text = f.read()
+        config_text += "\nCONFIG_WARN_CONTEXT_ANALYSIS=y"
+        config_text += "\nCONFIG_WERROR=y"
+        with open(kernel_config, "w") as f:
+            f.write(config_text)
+
+        return kernel_config

--- a/ci/checksparse.py
+++ b/ci/checksparse.py
@@ -31,7 +31,8 @@ class CheckSparse(GenericKernelBuild):
             self.dry_run = dry_run
 
         super().__init__(kernel_config=kernel_config, simple_build=True,
-                         make_params=['C=1'], work_dir=self.src_dir)
+                         make_params=['C=1'], work_dir=self.src_dir,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/checkvalgrind.py
+++ b/ci/checkvalgrind.py
@@ -31,7 +31,8 @@ class CheckValgrind(GenericBuild):
             tests_str = " ".join(test_list)
             make_params.append(f"TESTS={tests_str}")
         super().__init__(config_params=config_params, make_params=make_params,
-                         work_dir=ci_data.src_dir)
+                         work_dir=ci_data.src_dir,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/checkvalgrind.py
+++ b/ci/checkvalgrind.py
@@ -27,7 +27,8 @@ class CheckValgrind(GenericBuild):
         config_params = ["--disable-lsan", "--disable-asan"]
         make_params = ["check"]
         super().__init__(config_params=config_params, make_params=make_params,
-                         work_dir=ci_data.src_dir)
+                         work_dir=ci_data.src_dir,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/genericbuild.py
+++ b/ci/genericbuild.py
@@ -15,7 +15,7 @@ class GenericBuild(Base):
     def __init__(self, config_cmd=None, config_params=None,
                  make_cmd=None, make_params=None,
                  use_fakeroot=False, install=False, install_params=None,
-                 work_dir=None):
+                 work_dir=None, jobs=None):
 
         super().__init__()
 
@@ -40,6 +40,8 @@ class GenericBuild(Base):
 
         self.stderr = None
 
+        self.jobs = jobs if jobs else "4"
+
         self.log_dbg("Initialization completed")
 
     def run(self):
@@ -58,7 +60,7 @@ class GenericBuild(Base):
 
         # Make
         # AR: Maybe read from /proc for job count
-        cmd = [self.make_cmd, "-j4"]
+        cmd = [self.make_cmd, "-j" + str(self.jobs)]
         if self.use_fakeroot:
             cmd = ["fakeroot"] + cmd
         if self.make_params:

--- a/ci/genericbuild.py
+++ b/ci/genericbuild.py
@@ -15,7 +15,7 @@ class GenericBuild(Base):
     def __init__(self, config_cmd=None, config_params=None,
                  make_cmd=None, make_params=None,
                  use_fakeroot=False, install=False, install_params=None,
-                 work_dir=None):
+                 work_dir=None, jobs=None):
 
         super().__init__()
 
@@ -39,6 +39,7 @@ class GenericBuild(Base):
         self.install_params = install_params
 
         self.stderr = None
+        self.jobs = jobs
 
         self.log_dbg("Initialization completed")
 
@@ -58,7 +59,9 @@ class GenericBuild(Base):
 
         # Make
         # AR: Maybe read from /proc for job count
-        cmd = [self.make_cmd, "-j4"]
+        cmd = [self.make_cmd]
+        if self.jobs is not None:
+            cmd += [f"-j{self.jobs}"]
         if self.use_fakeroot:
             cmd = ["fakeroot"] + cmd
         if self.make_params:

--- a/ci/generickernelbuild.py
+++ b/ci/generickernelbuild.py
@@ -50,6 +50,8 @@ class GenericKernelBuild(Base):
         # Update .config
         self.log_info("GenericKernelBuild: Run make olddefconfig")
         cmd = ["make", "olddefconfig"]
+        if self.make_params:
+            cmd += self.make_params
         (ret, stdout, stderr) = cmd_run(cmd, cwd=self.work_dir)
         if ret:
             self.log_err("GenericKernelBuild: Failed to config the kernel")

--- a/ci/generickernelbuild.py
+++ b/ci/generickernelbuild.py
@@ -18,7 +18,7 @@ class GenericKernelBuild(Base):
     """
 
     def __init__(self, kernel_config=None, simple_build=True,
-                 make_params=None, work_dir=None):
+                 make_params=None, work_dir=None, jobs=None):
 
         super().__init__()
 
@@ -36,6 +36,8 @@ class GenericKernelBuild(Base):
 
         # Save the error output
         self.stderr = None
+
+        self.jobs = str(jobs) if jobs else "4"
 
         self.log_dbg("Initialization completed")
 
@@ -60,7 +62,7 @@ class GenericKernelBuild(Base):
         # make
         self.log_info("Run make")
 
-        base_cmd = ["make", "-j4"]
+        base_cmd = ["make", "-j" + self.jobs]
         if self.make_params:
             base_cmd += self.make_params
         self.log_dbg(f"GenericKernelBuild: Base Command: {base_cmd}")

--- a/ci/generickernelbuild.py
+++ b/ci/generickernelbuild.py
@@ -18,7 +18,7 @@ class GenericKernelBuild(Base):
     """
 
     def __init__(self, kernel_config=None, simple_build=True,
-                 make_params=None, work_dir=None):
+                 make_params=None, work_dir=None, jobs=None):
 
         super().__init__()
 
@@ -36,6 +36,8 @@ class GenericKernelBuild(Base):
 
         # Save the error output
         self.stderr = None
+
+        self.jobs = jobs
 
         self.log_dbg("Initialization completed")
 
@@ -60,7 +62,9 @@ class GenericKernelBuild(Base):
         # make
         self.log_info("Run make")
 
-        base_cmd = ["make", "-j4"]
+        base_cmd = ["make"]
+        if self.jobs is not None:
+            base_cmd += [f"-j{self.jobs}"]
         if self.make_params:
             base_cmd += self.make_params
         self.log_dbg(f"GenericKernelBuild: Base Command: {base_cmd}")

--- a/ci/incrementalbuild.py
+++ b/ci/incrementalbuild.py
@@ -29,6 +29,9 @@ class IncrementalBuild(Base):
         if self.space == "kernel" and not self.kernel_config:
             self.kernel_config = '/bluetooth_build.config'
 
+        jobs = ci_data.config.get('jobs')
+        self.jobs = str(jobs) if jobs else "4"
+
         super().__init__()
 
         self.log_dbg("Initialization completed")
@@ -57,7 +60,7 @@ class IncrementalBuild(Base):
     def _incremental_make(self):
         """Run make without reconfiguring - truly incremental."""
 
-        cmd = ["make", "-j4"]
+        cmd = ["make", "-j" + self.jobs]
         if self.space == "kernel":
             # Kernel simple build: only Bluetooth sources
             cmd.append('net/bluetooth/')

--- a/ci/incrementalbuild.py
+++ b/ci/incrementalbuild.py
@@ -29,6 +29,8 @@ class IncrementalBuild(Base):
         if self.space == "kernel" and not self.kernel_config:
             self.kernel_config = '/bluetooth_build.config'
 
+        self.jobs = ci_data.config.get('jobs')
+
         super().__init__()
 
         self.log_dbg("Initialization completed")
@@ -57,7 +59,9 @@ class IncrementalBuild(Base):
     def _incremental_make(self):
         """Run make without reconfiguring - truly incremental."""
 
-        cmd = ["make", "-j4"]
+        cmd = ["make"]
+        if self.jobs is not None:
+            cmd += [f"-j{self.jobs}"]
         if self.space == "kernel":
             # Kernel simple build: only Bluetooth sources
             cmd.append('net/bluetooth/')

--- a/ci/makedistcheck.py
+++ b/ci/makedistcheck.py
@@ -25,7 +25,8 @@ class MakeDistcheck(GenericBuild):
         config_params = ["--disable-lsan", "--disable-asan", "--disable-ubsan"]
         make_params = ["distcheck"]
         super().__init__(config_params=config_params, make_params=make_params,
-                         use_fakeroot=True, work_dir=ci_data.src_dir)
+                         use_fakeroot=True, work_dir=ci_data.src_dir,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/makeextell.py
+++ b/ci/makeextell.py
@@ -24,7 +24,8 @@ class MakeExtEll(GenericBuild):
         self.ci_data = ci_data
 
         config_params = ["--enable-external-ell", "--disable-lsan", "--disable-asan", "--disable-ubsan"]
-        super().__init__(config_params=config_params, work_dir=ci_data.src_dir)
+        super().__init__(config_params=config_params, work_dir=ci_data.src_dir,
+                         jobs=ci_data.config.get('jobs'))
 
         self.log_dbg("Initialization completed")
 

--- a/ci/scanbuild.py
+++ b/ci/scanbuild.py
@@ -19,6 +19,9 @@ class ScanBuild(Base):
         self.desc = "Run Scan Build"
         self.ci_data = ci_data
 
+        jobs = ci_data.config.get('jobs')
+        self.jobs = str(jobs) if jobs else "4"
+
         super().__init__()
 
         self.log_dbg("Initialization completed")
@@ -40,7 +43,7 @@ class ScanBuild(Base):
             self.add_failure_end_test(stderr)
 
         # Scan Build Make
-        cmd = ["scan-build", "make", "-j4"]
+        cmd = ["scan-build", "make", "-j" + self.jobs]
         (ret, stdout, stderr) = cmd_run(cmd, cwd=self.ci_data.src_dir)
         if ret:
             self.log_err("Scan Build failed")

--- a/ci/scanbuild.py
+++ b/ci/scanbuild.py
@@ -19,6 +19,8 @@ class ScanBuild(Base):
         self.desc = "Run Scan Build"
         self.ci_data = ci_data
 
+        self.jobs = ci_data.config.get('jobs')
+
         super().__init__()
 
         self.log_dbg("Initialization completed")
@@ -40,7 +42,9 @@ class ScanBuild(Base):
             self.add_failure_end_test(stderr)
 
         # Scan Build Make
-        cmd = ["scan-build", "make", "-j4"]
+        cmd = ["scan-build", "make"]
+        if self.jobs is not None:
+            cmd += [f"-j{self.jobs}"]
         (ret, stdout, stderr) = cmd_run(cmd, cwd=self.ci_data.src_dir)
         if ret:
             self.log_err("Scan Build failed")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -214,13 +214,13 @@ case $TASK in
                                        -k $GITHUB_WORKSPACE/$BASE_DIR/src      \
                                        -p $GITHUB_WORKSPACE/$BASE_DIR/patch    \
                                        kernel $GITHUB_REPOSITORY $PR	       \
-                                       --dry-run
+                                       --dry-run -j auto
             elif [ $SPACE == "user" ]; then
                 /ci.py -c /config.json -z $GITHUB_WORKSPACE/$BASE_DIR/src      \
                                        -e $GITHUB_WORKSPACE/$BASE_DIR/ell      \
                                        -p $GITHUB_WORKSPACE/$BASE_DIR/patch    \
                                        user $GITHUB_REPOSITORY $PR	       \
-                                       --dry-run
+                                       --dry-run -j auto
             else
                 echo "Unknown SPACE: $SPACE"
                 exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -173,9 +173,62 @@ case $TASK in
                 exit 1
             fi
         ;;
+    localci)
+        echo "Task: local CI"
+            mkdir -p /work
+            mkdir -p /work/base
+            GITHUB_WORKSPACE=/work
+            BASE_DIR=base
+
+            SPACE="$2"
+            GITHUB_REPOSITORY="$3"
+            PR="$4"
+
+            git config --global user.name "local"
+            git config --global user.email "local@users.noreply.github.com"
+
+            echo "Target ($SPACE): $GITHUB_REPOSITORY PR: $PR"
+
+            ls -l "$GITHUB_WORKSPACE/$BASE_DIR"
+            if ! test -d "$GITHUB_WORKSPACE/$BASE_DIR/src"; then
+                echo "Cloning https://github.com/$GITHUB_REPOSITORY"
+                git clone --depth 1 "https://github.com/$GITHUB_REPOSITORY" \
+                    $GITHUB_WORKSPACE/$BASE_DIR/src
+            fi
+            set_git_safe_dir $GITHUB_WORKSPACE/$BASE_DIR/src
+
+            if ! test -d "$GITHUB_WORKSPACE/$BASE_DIR/ell"; then
+                clone_ell $GITHUB_WORKSPACE/$BASE_DIR/ell
+            fi
+            set_git_safe_dir $GITHUB_WORKSPACE/$BASE_DIR/ell
+
+            mkdir $GITHUB_WORKSPACE/$BASE_DIR/patch
+
+            if [ $SPACE == "kernel" ]; then
+                if ! test -d "$GITHUB_WORKSPACE/$BASE_DIR/bluez"; then
+                    clone_bluez $GITHUB_WORKSPACE/$BASE_DIR/bluez
+                fi
+                set_git_safe_dir $GITHUB_WORKSPACE/$BASE_DIR/bluez
+                /ci.py -c /config.json -z $GITHUB_WORKSPACE/$BASE_DIR/bluez    \
+                                       -e $GITHUB_WORKSPACE/$BASE_DIR/ell      \
+                                       -k $GITHUB_WORKSPACE/$BASE_DIR/src      \
+                                       -p $GITHUB_WORKSPACE/$BASE_DIR/patch    \
+                                       kernel $GITHUB_REPOSITORY $PR	       \
+                                       --dry-run
+            elif [ $SPACE == "user" ]; then
+                /ci.py -c /config.json -z $GITHUB_WORKSPACE/$BASE_DIR/src      \
+                                       -e $GITHUB_WORKSPACE/$BASE_DIR/ell      \
+                                       -p $GITHUB_WORKSPACE/$BASE_DIR/patch    \
+                                       user $GITHUB_REPOSITORY $PR	       \
+                                       --dry-run
+            else
+                echo "Unknown SPACE: $SPACE"
+                exit 1
+            fi
+        ;;
     *)
         echo "Unknown TASK: $TASK"
-        eixt 1
+        exit 1
         ;;
 esac
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export PATH=/opt/llvm/bin:$PATH
+
 echo "Environment Variables:"
 echo "   Workflow:   $GITHUB_WORKFLOW"
 echo "   Action:     $GITHUB_ACTION"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -173,6 +173,59 @@ case $TASK in
                 exit 1
             fi
         ;;
+    localci)
+        echo "Task: local CI"
+            mkdir -p /work
+            mkdir -p /work/base
+            GITHUB_WORKSPACE=/work
+            BASE_DIR=base
+
+            SPACE="$2"
+            GITHUB_REPOSITORY="$3"
+            PR="$4"
+
+            git config --global user.name "local"
+            git config --global user.email "local@users.noreply.github.com"
+
+            echo "Target ($SPACE): $GITHUB_REPOSITORY PR: $PR"
+
+            ls -l "$GITHUB_WORKSPACE/$BASE_DIR"
+            if ! test -d "$GITHUB_WORKSPACE/$BASE_DIR/src"; then
+                echo "Cloning https://github.com/$GITHUB_REPOSITORY"
+                git clone --depth 1 "https://github.com/$GITHUB_REPOSITORY" \
+                    $GITHUB_WORKSPACE/$BASE_DIR/src
+            fi
+            set_git_safe_dir $GITHUB_WORKSPACE/$BASE_DIR/src
+
+            if ! test -d "$GITHUB_WORKSPACE/$BASE_DIR/ell"; then
+                clone_ell $GITHUB_WORKSPACE/$BASE_DIR/ell
+            fi
+            set_git_safe_dir $GITHUB_WORKSPACE/$BASE_DIR/ell
+
+            mkdir $GITHUB_WORKSPACE/$BASE_DIR/patch
+
+            if [ "$SPACE" == "kernel" ]; then
+                if ! test -d "$GITHUB_WORKSPACE/$BASE_DIR/bluez"; then
+                    clone_bluez $GITHUB_WORKSPACE/$BASE_DIR/bluez
+                fi
+                set_git_safe_dir $GITHUB_WORKSPACE/$BASE_DIR/bluez
+                /ci.py -c /config.json -z "$GITHUB_WORKSPACE/$BASE_DIR/bluez"  \
+                                       -e "$GITHUB_WORKSPACE/$BASE_DIR/ell"    \
+                                       -k "$GITHUB_WORKSPACE/$BASE_DIR/src"    \
+                                       -p "$GITHUB_WORKSPACE/$BASE_DIR/patch"  \
+                                       kernel "$GITHUB_REPOSITORY" "$PR"       \
+                                       --dry-run
+            elif [ "$SPACE" == "user" ]; then
+                /ci.py -c /config.json -z "$GITHUB_WORKSPACE/$BASE_DIR/src"    \
+                                       -e "$GITHUB_WORKSPACE/$BASE_DIR/ell"    \
+                                       -p "$GITHUB_WORKSPACE/$BASE_DIR/patch"  \
+                                       user "$GITHUB_REPOSITORY" "$PR"	       \
+                                       --dry-run
+            else
+                echo "Unknown SPACE: $SPACE"
+                exit 1
+            fi
+        ;;
     *)
         echo "Unknown TASK: $TASK"
         exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -214,13 +214,13 @@ case $TASK in
                                        -k "$GITHUB_WORKSPACE/$BASE_DIR/src"    \
                                        -p "$GITHUB_WORKSPACE/$BASE_DIR/patch"  \
                                        kernel "$GITHUB_REPOSITORY" "$PR"       \
-                                       --dry-run
+                                       --dry-run -j auto
             elif [ "$SPACE" == "user" ]; then
                 /ci.py -c /config.json -z "$GITHUB_WORKSPACE/$BASE_DIR/src"    \
                                        -e "$GITHUB_WORKSPACE/$BASE_DIR/ell"    \
                                        -p "$GITHUB_WORKSPACE/$BASE_DIR/patch"  \
                                        user "$GITHUB_REPOSITORY" "$PR"	       \
-                                       --dry-run
+                                       --dry-run -j auto
             else
                 echo "Unknown SPACE: $SPACE"
                 exit 1

--- a/libs/context.py
+++ b/libs/context.py
@@ -43,17 +43,15 @@ class Context():
         # Init github
         log_info(f"Initialize Github: {github_repo}")
         if 'GITHUB_TOKEN' not in os.environ:
-            log_error("Set GITHUB_TOKEN environment variable")
-            raise ContextError
+            log_info("GITHUB_TOKEN environment variable not set")
 
         # Use a separate token for Check Runs API (requires GitHub App token,
         # not a PAT). Falls back to GITHUB_TOKEN if not set.
-        checks_token = os.environ.get('GITHUB_CHECKS_TOKEN',
-                                       os.environ['GITHUB_TOKEN'])
+        token = os.environ.get('GITHUB_TOKEN', None)
+        checks_token = os.environ.get('GITHUB_CHECKS_TOKEN', token)
 
         try:
-            self.gh = GithubTool(github_repo, os.environ['GITHUB_TOKEN'],
-                                 checks_token=checks_token)
+            self.gh = GithubTool(github_repo, token, checks_token=checks_token)
         except:
             log_error("Failed to initialize GithubTool class")
             raise ContextError


### PR DESCRIPTION
Add task to build kernel with LLVM + checking context analysis warnings:
https://docs.kernel.org/dev-tools/context-analysis.html

This feature does static compile time checking of the __must_hold,
__guarded_by etc annotations now used by kernel, as support for Sparse locking analysis was removed.

Kernel CONTEXT_ANALYSIS requires LLVM 22 (and apparently LLVM 23 in near future), so this also needs someone to update the [blueztestbot docker image](https://hub.docker.com/r/blueztestbot/bluez-build): https://github.com/BluezTestBot/docker-bluez-build/pull/2

-----

Also add new `entrypoint.sh` command to run the Docker image locally, so that it is possible to test it without having BlueZ github secrets.

## Example:

```
$ export IMG=b4ce213a0d6ba1e743509dba866c865ee01399657c3324f9bc747c23a7675e6c
$ git clone --depth 1 https://github.com/bluez/bluetooth-next work/src
$ docker run --volume $PWD/work:/work/base:O $IMG localci kernel bluez/bluetooth-next 103
...
Test Summary:
CheckPatch                    PASS      3.08 seconds
GitLint                       FAIL      1539.75 seconds
SubjectPrefix                 PASS      0.00 seconds
BuildKernel                   PASS      43.56 seconds
CheckAllWarning               PASS      76.82 seconds
CheckSparse                   WARNING   142.24 seconds
BuildKernel32                 PASS      96.15 seconds
CheckKernelLLVM               WARNING   88.40 seconds
TestRunnerSetup               PASS      790.86 seconds
TestRunner_sco-tester         PASS      24.53 seconds
IncrementalBuild              PASS      108.80 seconds
...
##############################
Test: CheckKernelLLVM - WARNING
Desc: Build kernel with LLVM + context analysis
Output:
net/bluetooth/sco.c:266:7: warning: calling function 'sco_sock_hold' requires holding spinlock 'sco_conn_hold_unless_zero(conn).lock' exclusively [-Wthread-safety-analysis]  266 |         sk = sco_sock_hold(conn);      |              ^1 warning generated.
```
... in the case where we had the following in the kernel source to demonstrate an error
```diff
diff --git a/net/bluetooth/Makefile b/net/bluetooth/Makefile
index a7eede7616d..5fcc93fdd54 100644
--- a/net/bluetooth/Makefile
+++ b/net/bluetooth/Makefile
@@ -26,3 +26,5 @@ bluetooth-$(CONFIG_BT_MSFTEXT) += msft.o
 bluetooth-$(CONFIG_BT_AOSPEXT) += aosp.o
 bluetooth-$(CONFIG_BT_DEBUGFS) += hci_debugfs.o
 bluetooth-$(CONFIG_BT_SELFTEST) += selftest.o
+
+CONTEXT_ANALYSIS_sco.o := y
diff --git a/net/bluetooth/sco.c b/net/bluetooth/sco.c
index 3a5479538e8..05257c55517 100644
--- a/net/bluetooth/sco.c
+++ b/net/bluetooth/sco.c
@@ -129,6 +129,7 @@ static struct sco_conn *sco_conn_hold_unless_zero(struct sco_conn *conn)
 }
 
 static struct sock *sco_sock_hold(struct sco_conn *conn)
+       __must_hold(&conn->lock)
 {
        if (!conn || !bt_sock_linked(&sco_sk_list, conn->sk))
                return NULL;
@@ -262,8 +263,8 @@ static void sco_conn_del(struct hci_conn *hcon, int err)
 
        BT_DBG("hcon %p conn %p, err %d", hcon, conn, err);
 
-       sco_conn_lock(conn);
        sk = sco_sock_hold(conn);
+       sco_conn_lock(conn);
        sco_conn_unlock(conn);
        sco_conn_put(conn);
```