### PR TITLE
Use CI image in Github container registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM blueztestbot/bluez-build:latest
+FROM ghcr.io/pv/bluez-ci-image:latest
 
 COPY *.sh           /
 COPY *.py           /

--- a/ci/testrunner.py
+++ b/ci/testrunner.py
@@ -57,9 +57,12 @@ class TestRunner(Base):
                             None, self.ci_data.config['dry_run'])
             self.add_failure_end_test("No tester found")
 
-        # Running tester under valgrind for crash backtrace and memory checking
+        # Running tester with ASAN
+        asan_options = dict(exitcode=65, detect_leaks=0, print_summary=1)
+        asan_str=":".join(f"{k}={v}" for k, v in asan_options.items())
+
         cmd = [self.test_runner, "-k", self.test_img, "--",
-               "valgrind", "--error-exitcode=65", tester_path]
+               "/usr/bin/env", f"ASAN_OPTIONS={asan_str}", tester_path]
         (ret, stdout, stderr) = cmd_run(cmd, cwd=self.bluez_src_dir)
         if ret:
             self.log_err("Test failed to run")
@@ -132,6 +135,15 @@ class TestRunner(Base):
                 # Capture valgrind error summary and preceding context
                 splat = lines[max(0, lineno-30):lineno+1]
                 self.add_failure("Valgrind errors:\n" + "\n".join(splat))
+
+            if re.search(r"==\d+==\s*ERROR: .*Sanitizer:", line):
+                # Capture sanitizer error summary and preceding context
+                splat = lines[lineno:lineno+30]
+                for j, splatline in enumerate(splat):
+                    if 'SUMMARY:' in splatline and j > 2:
+                        splat = splat[:j+1]
+                        break
+                self.add_failure("Sanitizer errors:\n" + "\n".join(splat))
 
             if re.search(r"^Test Summary", line):
                 self.log_dbg("Start to check fail in the line")

--- a/ci/testrunnersetup.py
+++ b/ci/testrunnersetup.py
@@ -25,7 +25,7 @@ class TestRunnerSetup(Base):
             self.tester_config = "/tester.config"
 
         # BlueZ build object
-        _params = ["--disable-lsan", "--disable-asan", "--disable-ubsan"]
+        _params = ["--disable-lsan"]
         self.bluez_build = BuildBluez(ci_data, config_params=_params,
                                       src_dir=self.bluez_src_dir,
                                       dry_run=True)


### PR DESCRIPTION
Use image from Github container registry, built via Github actions so that it is easier to manage, without needing dockerhub or any other additional secrets.

This image includes LLVM 23 prerelease from kernel.org.

NOTE: The image is currently built from my personal account, https://github.com/pv/bluez-ci-image/pkgs/container/bluez-ci-image but probably the repository should be copied in the organization and the image name changed accordingly, `pv/bluez-ci-image` -> `bluez/ci-image` or similar